### PR TITLE
Update check_status to better support different types of errors

### DIFF
--- a/lib/google/apis/errors.rb
+++ b/lib/google/apis/errors.rb
@@ -61,6 +61,10 @@ module Google
     class RateLimitError < Error
     end
 
+    # A 403 HTTP error occurred.
+    class ProjectNotLinkedError < Error
+    end
+
     # A 401 HTTP error occurred.
     class AuthorizationError < Error
     end

--- a/spec/google/apis/core/api_command_spec.rb
+++ b/spec/google/apis/core/api_command_spec.rb
@@ -159,6 +159,44 @@ EOF
     end
   end
 
+  context('with a project not linked response') do
+    let(:command) do
+      Google::Apis::Core::ApiCommand.new(:get, 'https://www.googleapis.com/zoo/animals')
+    end
+
+    before(:example) do
+      json = <<EOF
+{
+ "error": {
+  "errors": [
+   {
+    "domain": "global",
+    "reason": "projectNotLinked",
+    "message": "The project id used to call the Google Play Developer API has not been linked in the Google Play Developer Console."
+   }
+  ],
+  "code": 403,
+  "message": "The project id used to call the Google Play Developer API has not been linked in the Google Play Developer Console."
+ }
+}
+EOF
+      stub_request(:get, 'https://www.googleapis.com/zoo/animals')
+        .to_return(status: [403, 'The project id used to call the Google Play Developer API has not been linked in the Google Play Developer Console.'], headers: {
+          'Content-Type' => 'application/json'
+        }, body: json)
+        .to_return(headers: { 'Content-Type' => 'application/json' }, body: %({}))
+    end
+
+    it 'should raise project not linked error' do
+      expect { command.execute(client) }.to raise_error(Google::Apis::ProjectNotLinkedError)
+    end
+
+    it 'should raise an error with the reason and message' do
+      expect { command.execute(client) }.to raise_error(
+        /projectNotLinked: The project id used to call the Google Play Developer API has not been linked in the Google Play Developer Console./)
+    end
+  end
+
   context('with a client error response') do
     let(:command) do
       Google::Apis::Core::ApiCommand.new(:get, 'https://www.googleapis.com/zoo/animals')


### PR DESCRIPTION
A `Google::Apis::ClientError` currently indicates that a request is invalid and should not be retried without modification. `check_status` in `Google::Apis::Core::ApiCommand` however, is returning this error for both retriable and non-retriable errors, such as `reviewQueryQuotaExceeded` and `projectNotLinked` respectively. 

This is not only incorrect, but the implementation makes it difficult for consumers to decide what to do without pattern matching against the error message.

This pull request takes the existing whitelisting logic for handling rate limit errors, and makes it more generic to support handling other types of errors.